### PR TITLE
Add setup file to allow python install commands

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+   name='prtools',
+   version='1.0',
+   description='Bare-bones implementation of Prtools for Python',
+   author='D.M.J. Tax',
+   author_email='',
+   packages=[],
+   install_requires=['sklearn', 'numpy', 'matplotlib'],
+)


### PR DESCRIPTION
Without this file, python3 does not allow for installation with pip3.

Installation is now possible with `pip3 install git+https://github.com/DMJTax/prtools.git`