### PR TITLE
Bugfix, fix ridger dimension

### DIFF
--- a/prtools/prtools.py
+++ b/prtools/prtools.py
@@ -1543,7 +1543,7 @@ def ridger(task=None,x=None,w=None):
         # we are going to train the mapping
         n,dim = x.shape
         dat = numpy.hstack((+x,numpy.ones((n,1))))
-        Sinv = numpy.linalg.inv(dat.T.dot(dat) + w*numpy.eye(dim))
+        Sinv = numpy.linalg.inv(dat.T.dot(dat) + w*numpy.eye(dim+1))
         beta = Sinv.dot(dat.T).dot(x.targets)
         # store the parameters, and labels:
         return beta,['target']


### PR DESCRIPTION
Ridger dimension was wrong, does not account for the extra columns of ones that is added for intercept.

It seemed to work for 1D data, because it interpreted the 1D identity matrix and a scalar and added it to each component of the matrix. For n-D data it failed because of the dimension mismatch.