### PR TITLE
Update name of sklearn package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
    author='D.M.J. Tax',
    author_email='',
    packages=['prtools'],
-   install_requires=['sklearn', 'numpy', 'matplotlib', 'requests'],
+   install_requires=['scikit-learn', 'numpy', 'matplotlib', 'requests'],
    package_data={
        'prtools': [os.path.join('data','*.mat')],
        },


### PR DESCRIPTION
pip install did not work with "sklearn" in install_requires in setup.py
changed it to "scikit-learn" and it works fine now